### PR TITLE
CLOSES #3 - Refresh UI

### DIFF
--- a/internal/interface/web/server.go
+++ b/internal/interface/web/server.go
@@ -23,6 +23,7 @@ func NewServer(svc *appservice.RecipeService, db *sql.DB, addr string, sessionSe
 
 	e.Use(echomw.Logger())
 	e.Use(echomw.Recover())
+	e.Static("/static", "static")
 
 	store := sessions.NewCookieStore([]byte(sessionSecret))
 

--- a/internal/interface/web/template/home.templ
+++ b/internal/interface/web/template/home.templ
@@ -6,37 +6,29 @@ import (
 
 templ Home(recipes []dto.RecipeResult, userEmail string) {
 	@Layout("Home", userEmail) {
-		<div class="columns">
-			<div class="column is-8 is-offset-2">
-				<div class="box" data-signals:search="">
-					<h2 class="title is-4">Search Recipes</h2>
-					<div class="field">
-						<div class="control">
-							<input
-								class="input is-medium"
-								type="text"
-								placeholder="Search by name, ingredient, cuisine..."
-								data-bind:search
-								data-on:keyup__debounce.300ms="@get('/search/results')"
-							/>
-						</div>
-					</div>
-					<div id="search-results"></div>
-				</div>
+		<div class="panel" data-signals:search="">
+			<h2 class="section-title">Search Recipes</h2>
+			<div class="form-group">
+				<input
+					class="form-input input-lg"
+					type="text"
+					placeholder="Search by name, ingredient, cuisine..."
+					data-bind:search
+					data-on:keyup__debounce.300ms="@get('/search/results')"
+				/>
 			</div>
+			<div id="search-results"></div>
 		</div>
-		<div class="mt-5">
-			<h2 class="title is-4">Recent Recipes</h2>
+		<div class="mt-4">
+			<h2 class="section-title">Recent Recipes</h2>
 			if len(recipes) == 0 {
-				<div class="notification is-info is-light">
+				<div class="alert alert-info">
 					No recipes yet. <a href="/import">Import one</a> to get started!
 				</div>
 			} else {
-				<div class="columns is-multiline">
+				<div class="card-grid">
 					for _, r := range recipes {
-						<div class="column is-4">
-							@RecipeCard(r)
-						</div>
+						@RecipeCard(r)
 					}
 				</div>
 			}

--- a/internal/interface/web/template/home_templ.go
+++ b/internal/interface/web/template/home_templ.go
@@ -45,40 +45,32 @@ func Home(recipes []dto.RecipeResult, userEmail string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"columns\"><div class=\"column is-8 is-offset-2\"><div class=\"box\" data-signals:search=\"\"><h2 class=\"title is-4\">Search Recipes</h2><div class=\"field\"><div class=\"control\"><input class=\"input is-medium\" type=\"text\" placeholder=\"Search by name, ingredient, cuisine...\" data-bind:search data-on:keyup__debounce.300ms=\"@get('/search/results')\"></div></div><div id=\"search-results\"></div></div></div></div><div class=\"mt-5\"><h2 class=\"title is-4\">Recent Recipes</h2>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"panel\" data-signals:search=\"\"><h2 class=\"section-title\">Search Recipes</h2><div class=\"form-group\"><input class=\"form-input input-lg\" type=\"text\" placeholder=\"Search by name, ingredient, cuisine...\" data-bind:search data-on:keyup__debounce.300ms=\"@get('/search/results')\"></div><div id=\"search-results\"></div></div><div class=\"mt-4\"><h2 class=\"section-title\">Recent Recipes</h2>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(recipes) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"notification is-info is-light\">No recipes yet. <a href=\"/import\">Import one</a> to get started!</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"alert alert-info\">No recipes yet. <a href=\"/import\">Import one</a> to get started!</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"columns is-multiline\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"card-grid\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, r := range recipes {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"column is-4\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
 					templ_7745c5c3_Err = RecipeCard(r).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/internal/interface/web/template/layout.templ
+++ b/internal/interface/web/template/layout.templ
@@ -1,38 +1,26 @@
 package template
 
 templ Navbar(userEmail string) {
-	<nav class="navbar is-primary" role="navigation" aria-label="main navigation">
+	<nav class="navbar">
 		<div class="container">
-			<div class="navbar-brand">
-				<a class="navbar-item has-text-weight-bold" href="/">RecipeBox</a>
-				<a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarMenu"
-					onclick="this.classList.toggle('is-active'); document.getElementById('navbarMenu').classList.toggle('is-active');">
-					<span aria-hidden="true"></span>
-					<span aria-hidden="true"></span>
-					<span aria-hidden="true"></span>
-					<span aria-hidden="true"></span>
-				</a>
-			</div>
+			<a class="navbar-brand" href="/">RecipeBox</a>
+			<button class="navbar-burger" aria-label="menu"
+				onclick="document.getElementById('navbarMenu').classList.toggle('is-open')">
+				&#9776;
+			</button>
 			<div id="navbarMenu" class="navbar-menu">
-				<div class="navbar-start">
-					<a class="navbar-item" href="/">Home</a>
-					<a class="navbar-item" href="/recipes">Browse</a>
-					<a class="navbar-item" href="/import">Import</a>
+				<div class="navbar-links">
+					<a href="/">Home</a>
+					<a href="/recipes">Browse</a>
+					<a href="/import">Import</a>
 				</div>
 				<div class="navbar-end">
 					if userEmail != "" {
-						<div class="navbar-item">
-							<span class="has-text-light">{ userEmail }</span>
-						</div>
-						<div class="navbar-item">
-							<form method="POST" action="/logout">
-								<button class="button is-small is-light" type="submit">Logout</button>
-							</form>
-						</div>
+						<span class="navbar-email">{ userEmail }</span>
+						<form method="POST" action="/logout">
+							<button class="btn btn-ghost btn-sm" type="submit">Logout</button>
+						</form>
 					}
-					<a class="navbar-item" id="theme-toggle" onclick="toggleTheme()" title="Toggle dark mode">
-						<span class="icon"><i id="theme-icon" class="fa-solid fa-moon"></i></span>
-					</a>
 				</div>
 			</div>
 		</div>
@@ -46,45 +34,19 @@ templ Layout(title string, userEmail string) {
 			<meta charset="UTF-8"/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<title>{ title } - RecipeBox</title>
-			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css"/>
+			<link rel="preconnect" href="https://fonts.googleapis.com"/>
+			<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+			<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+			<link rel="stylesheet" href="/static/style.css"/>
 			<script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js"></script>
-			<script src="https://kit.fontawesome.com/ba546e039f.js" crossorigin="anonymous"></script>
-			<style>
-				.recipe-card .card-image img {
-					object-fit: cover;
-					height: 200px;
-					width: 100%;
-				}
-			</style>
 		</head>
 		<body>
 			@Navbar(userEmail)
-			<section class="section">
+			<div class="page-content">
 				<div class="container">
 					{ children... }
 				</div>
-			</section>
-		<script>
-			function getPreferredTheme() {
-				const stored = localStorage.getItem('theme');
-				if (stored) return stored;
-				return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-			}
-			function applyTheme(theme) {
-				document.documentElement.setAttribute('data-theme', theme);
-				const icon = document.getElementById('theme-icon');
-				if (icon) {
-					icon.className = theme === 'dark' ? 'fa-solid fa-sun' : 'fa-solid fa-moon';
-				}
-			}
-			function toggleTheme() {
-				const current = document.documentElement.getAttribute('data-theme') || getPreferredTheme();
-				const next = current === 'dark' ? 'light' : 'dark';
-				localStorage.setItem('theme', next);
-				applyTheme(next);
-			}
-			applyTheme(getPreferredTheme());
-		</script>
+			</div>
 		</body>
 	</html>
 }

--- a/internal/interface/web/template/layout_templ.go
+++ b/internal/interface/web/template/layout_templ.go
@@ -29,30 +29,30 @@ func Navbar(userEmail string) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<nav class=\"navbar is-primary\" role=\"navigation\" aria-label=\"main navigation\"><div class=\"container\"><div class=\"navbar-brand\"><a class=\"navbar-item has-text-weight-bold\" href=\"/\">RecipeBox</a> <a role=\"button\" class=\"navbar-burger\" aria-label=\"menu\" aria-expanded=\"false\" data-target=\"navbarMenu\" onclick=\"this.classList.toggle('is-active'); document.getElementById('navbarMenu').classList.toggle('is-active');\"><span aria-hidden=\"true\"></span> <span aria-hidden=\"true\"></span> <span aria-hidden=\"true\"></span> <span aria-hidden=\"true\"></span></a></div><div id=\"navbarMenu\" class=\"navbar-menu\"><div class=\"navbar-start\"><a class=\"navbar-item\" href=\"/\">Home</a> <a class=\"navbar-item\" href=\"/recipes\">Browse</a> <a class=\"navbar-item\" href=\"/import\">Import</a></div><div class=\"navbar-end\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<nav class=\"navbar\"><div class=\"container\"><a class=\"navbar-brand\" href=\"/\">RecipeBox</a> <button class=\"navbar-burger\" aria-label=\"menu\" onclick=\"document.getElementById('navbarMenu').classList.toggle('is-open')\">&#9776;</button><div id=\"navbarMenu\" class=\"navbar-menu\"><div class=\"navbar-links\"><a href=\"/\">Home</a> <a href=\"/recipes\">Browse</a> <a href=\"/import\">Import</a></div><div class=\"navbar-end\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if userEmail != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"navbar-item\"><span class=\"has-text-light\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<span class=\"navbar-email\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(userEmail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/layout.templ`, Line: 25, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/layout.templ`, Line: 19, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</span></div><div class=\"navbar-item\"><form method=\"POST\" action=\"/logout\"><button class=\"button is-small is-light\" type=\"submit\">Logout</button></form></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</span><form method=\"POST\" action=\"/logout\"><button class=\"btn btn-ghost btn-sm\" type=\"submit\">Logout</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<a class=\"navbar-item\" id=\"theme-toggle\" onclick=\"toggleTheme()\" title=\"Toggle dark mode\"><span class=\"icon\"><i id=\"theme-icon\" class=\"fa-solid fa-moon\"></i></span></a></div></div></div></nav>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div></div></nav>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -88,13 +88,13 @@ func Layout(title string, userEmail string) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/layout.templ`, Line: 48, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/layout.templ`, Line: 36, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " - RecipeBox</title><link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css\"><script type=\"module\" src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js\"></script><script src=\"https://kit.fontawesome.com/ba546e039f.js\" crossorigin=\"anonymous\"></script><style>\n\t\t\t\t.recipe-card .card-image img {\n\t\t\t\t\tobject-fit: cover;\n\t\t\t\t\theight: 200px;\n\t\t\t\t\twidth: 100%;\n\t\t\t\t}\n\t\t\t</style></head><body>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " - RecipeBox</title><link rel=\"preconnect\" href=\"https://fonts.googleapis.com\"><link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin><link href=\"https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap\" rel=\"stylesheet\"><link rel=\"stylesheet\" href=\"/static/style.css\"><script type=\"module\" src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js\"></script></head><body>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -102,7 +102,7 @@ func Layout(title string, userEmail string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<section class=\"section\"><div class=\"container\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"page-content\"><div class=\"container\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -110,7 +110,7 @@ func Layout(title string, userEmail string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></section><script>\n\t\t\tfunction getPreferredTheme() {\n\t\t\t\tconst stored = localStorage.getItem('theme');\n\t\t\t\tif (stored) return stored;\n\t\t\t\treturn window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';\n\t\t\t}\n\t\t\tfunction applyTheme(theme) {\n\t\t\t\tdocument.documentElement.setAttribute('data-theme', theme);\n\t\t\t\tconst icon = document.getElementById('theme-icon');\n\t\t\t\tif (icon) {\n\t\t\t\t\ticon.className = theme === 'dark' ? 'fa-solid fa-sun' : 'fa-solid fa-moon';\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction toggleTheme() {\n\t\t\t\tconst current = document.documentElement.getAttribute('data-theme') || getPreferredTheme();\n\t\t\t\tconst next = current === 'dark' ? 'light' : 'dark';\n\t\t\t\tlocalStorage.setItem('theme', next);\n\t\t\t\tapplyTheme(next);\n\t\t\t}\n\t\t\tapplyTheme(getPreferredTheme());\n\t\t</script></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/interface/web/template/login.templ
+++ b/internal/interface/web/template/login.templ
@@ -2,35 +2,27 @@ package template
 
 templ Login(errMsg string) {
 	@Layout("Login", "") {
-		<div class="columns">
-			<div class="column is-4 is-offset-4">
-				<h1 class="title">Login</h1>
-				if errMsg != "" {
-					<div class="notification is-danger">{ errMsg }</div>
-				}
-				<form method="POST" action="/login">
-					<div class="field">
-						<label class="label">Email</label>
-						<div class="control">
-							<input class="input" type="email" name="email" placeholder="you@example.com" required/>
-						</div>
-					</div>
-					<div class="field">
-						<label class="label">Password</label>
-						<div class="control">
-							<input class="input" type="password" name="password" required/>
-						</div>
-					</div>
-					<div class="field">
-						<div class="control">
-							<button class="button is-primary is-fullwidth" type="submit">Login</button>
-						</div>
-					</div>
-				</form>
-				<p class="has-text-centered mt-4">
-					Don't have an account? <a href="/register">Register</a>
-				</p>
-			</div>
+		<div class="auth-container">
+			<h1 class="page-title">Login</h1>
+			if errMsg != "" {
+				<div class="alert alert-danger">{ errMsg }</div>
+			}
+			<form method="POST" action="/login">
+				<div class="form-group">
+					<label class="form-label">Email</label>
+					<input class="form-input" type="email" name="email" placeholder="you@example.com" required/>
+				</div>
+				<div class="form-group">
+					<label class="form-label">Password</label>
+					<input class="form-input" type="password" name="password" required/>
+				</div>
+				<div class="form-group">
+					<button class="btn btn-primary btn-block" type="submit">Login</button>
+				</div>
+			</form>
+			<p class="text-center text-secondary mt-3">
+				Don't have an account? <a href="/register">Register</a>
+			</p>
 		</div>
 	}
 }

--- a/internal/interface/web/template/login_templ.go
+++ b/internal/interface/web/template/login_templ.go
@@ -41,19 +41,19 @@ func Login(errMsg string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"columns\"><div class=\"column is-4 is-offset-4\"><h1 class=\"title\">Login</h1>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"auth-container\"><h1 class=\"page-title\">Login</h1>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if errMsg != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"notification is-danger\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"alert alert-danger\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var3 string
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(errMsg)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/login.templ`, Line: 9, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/login.templ`, Line: 8, Col: 44}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
@@ -64,7 +64,7 @@ func Login(errMsg string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<form method=\"POST\" action=\"/login\"><div class=\"field\"><label class=\"label\">Email</label><div class=\"control\"><input class=\"input\" type=\"email\" name=\"email\" placeholder=\"you@example.com\" required></div></div><div class=\"field\"><label class=\"label\">Password</label><div class=\"control\"><input class=\"input\" type=\"password\" name=\"password\" required></div></div><div class=\"field\"><div class=\"control\"><button class=\"button is-primary is-fullwidth\" type=\"submit\">Login</button></div></div></form><p class=\"has-text-centered mt-4\">Don't have an account? <a href=\"/register\">Register</a></p></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<form method=\"POST\" action=\"/login\"><div class=\"form-group\"><label class=\"form-label\">Email</label> <input class=\"form-input\" type=\"email\" name=\"email\" placeholder=\"you@example.com\" required></div><div class=\"form-group\"><label class=\"form-label\">Password</label> <input class=\"form-input\" type=\"password\" name=\"password\" required></div><div class=\"form-group\"><button class=\"btn btn-primary btn-block\" type=\"submit\">Login</button></div></form><p class=\"text-center text-secondary mt-3\">Don't have an account? <a href=\"/register\">Register</a></p></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/internal/interface/web/template/pagination.templ
+++ b/internal/interface/web/template/pagination.templ
@@ -4,12 +4,12 @@ import "fmt"
 
 templ Pagination(total, offset, limit int) {
 	if total > limit {
-		<nav class="pagination is-centered mt-5" role="navigation" aria-label="pagination">
+		<nav class="pagination" role="navigation" aria-label="pagination">
 			if offset > 0 {
-				<a class="pagination-previous" href={ templ.SafeURL(fmt.Sprintf("?offset=%d&limit=%d", max(0, offset-limit), limit)) }>Previous</a>
+				<a class="pagination-btn" href={ templ.SafeURL(fmt.Sprintf("?offset=%d&limit=%d", max(0, offset-limit), limit)) }>Previous</a>
 			}
 			if offset+limit < total {
-				<a class="pagination-next" href={ templ.SafeURL(fmt.Sprintf("?offset=%d&limit=%d", offset+limit, limit)) }>Next</a>
+				<a class="pagination-btn" href={ templ.SafeURL(fmt.Sprintf("?offset=%d&limit=%d", offset+limit, limit)) }>Next</a>
 			}
 		</nav>
 	}

--- a/internal/interface/web/template/pagination_templ.go
+++ b/internal/interface/web/template/pagination_templ.go
@@ -32,19 +32,19 @@ func Pagination(total, offset, limit int) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if total > limit {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<nav class=\"pagination is-centered mt-5\" role=\"navigation\" aria-label=\"pagination\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<nav class=\"pagination\" role=\"navigation\" aria-label=\"pagination\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if offset > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<a class=\"pagination-previous\" href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<a class=\"pagination-btn\" href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var2 templ.SafeURL
 				templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("?offset=%d&limit=%d", max(0, offset-limit), limit)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/pagination.templ`, Line: 9, Col: 120}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/pagination.templ`, Line: 9, Col: 115}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 				if templ_7745c5c3_Err != nil {
@@ -56,14 +56,14 @@ func Pagination(total, offset, limit int) templ.Component {
 				}
 			}
 			if offset+limit < total {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<a class=\"pagination-next\" href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<a class=\"pagination-btn\" href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var3 templ.SafeURL
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("?offset=%d&limit=%d", offset+limit, limit)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/pagination.templ`, Line: 12, Col: 108}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/pagination.templ`, Line: 12, Col: 107}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {

--- a/internal/interface/web/template/recipe_card.templ
+++ b/internal/interface/web/template/recipe_card.templ
@@ -6,33 +6,31 @@ import (
 )
 
 templ RecipeCard(r dto.RecipeResult) {
-	<div class="card recipe-card">
+	<div class="card">
 		if r.ImageURL != "" {
 			<div class="card-image">
-				<figure class="image">
-					<img src={ r.ImageURL } alt={ r.Title }/>
-				</figure>
+				<img src={ r.ImageURL } alt={ r.Title }/>
 			</div>
 		}
-		<div class="card-content">
-			<p class="title is-5">
+		<div class="card-body">
+			<div class="card-title">
 				<a href={ templ.SafeURL(fmt.Sprintf("/recipes/%s", r.ID)) }>{ r.Title }</a>
-			</p>
+			</div>
 			if r.Author != "" {
-				<p class="subtitle is-6 has-text-grey">by { r.Author }</p>
+				<div class="card-subtitle">by { r.Author }</div>
 			}
-			<div class="tags">
+			<div class="badge-group">
 				if r.TotalTime != "" {
-					<span class="tag is-info is-light">{ r.TotalTime }</span>
+					<span class="badge badge-info">{ r.TotalTime }</span>
 				}
 				if r.Cuisine != "" {
-					<span class="tag is-success is-light">{ r.Cuisine }</span>
+					<span class="badge badge-success">{ r.Cuisine }</span>
 				}
 				if r.Course != "" {
-					<span class="tag is-warning is-light">{ r.Course }</span>
+					<span class="badge badge-warning">{ r.Course }</span>
 				}
 				if r.Servings != "" {
-					<span class="tag is-primary is-light">{ fmt.Sprintf("Serves %s", r.Servings) }</span>
+					<span class="badge badge-accent">{ fmt.Sprintf("Serves %s", r.Servings) }</span>
 				}
 			</div>
 		</div>

--- a/internal/interface/web/template/recipe_card_templ.go
+++ b/internal/interface/web/template/recipe_card_templ.go
@@ -34,19 +34,19 @@ func RecipeCard(r dto.RecipeResult) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"card recipe-card\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"card\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if r.ImageURL != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"card-image\"><figure class=\"image\"><img src=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"card-image\"><img src=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(r.ImageURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 13, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 12, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -59,25 +59,25 @@ func RecipeCard(r dto.RecipeResult) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(r.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 13, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 12, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\"></figure></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"card-content\"><p class=\"title is-5\"><a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"card-body\"><div class=\"card-title\"><a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/recipes/%s", r.ID)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 19, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 17, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -90,48 +90,48 @@ func RecipeCard(r dto.RecipeResult) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(r.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 19, Col: 73}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 17, Col: 73}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</a></p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</a></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if r.Author != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<p class=\"subtitle is-6 has-text-grey\">by ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"card-subtitle\">by ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(r.Author)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 22, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 20, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"tags\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"badge-group\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if r.TotalTime != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<span class=\"tag is-info is-light\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<span class=\"badge badge-info\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(r.TotalTime)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 26, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 24, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -143,14 +143,14 @@ func RecipeCard(r dto.RecipeResult) templ.Component {
 			}
 		}
 		if r.Cuisine != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<span class=\"tag is-success is-light\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<span class=\"badge badge-success\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(r.Cuisine)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 29, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 27, Col: 50}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -162,14 +162,14 @@ func RecipeCard(r dto.RecipeResult) templ.Component {
 			}
 		}
 		if r.Course != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<span class=\"tag is-warning is-light\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<span class=\"badge badge-warning\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(r.Course)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 32, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 30, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -181,14 +181,14 @@ func RecipeCard(r dto.RecipeResult) templ.Component {
 			}
 		}
 		if r.Servings != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<span class=\"tag is-primary is-light\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<span class=\"badge badge-accent\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Serves %s", r.Servings))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 35, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_card.templ`, Line: 33, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {

--- a/internal/interface/web/template/recipe_detail.templ
+++ b/internal/interface/web/template/recipe_detail.templ
@@ -25,71 +25,65 @@ func ingredientDisplay(ing dto.IngredientResult) string {
 
 templ RecipeDetail(r dto.RecipeResult, userEmail string) {
 	@Layout(r.Title, userEmail) {
-		<div class="columns">
-			<div class="column is-8">
-				<h1 class="title">{ r.Title }</h1>
+		<div class="grid">
+			<div class="col-8">
+				<h1 class="page-title">{ r.Title }</h1>
 				if r.Author != "" {
-					<p class="subtitle is-6 has-text-grey">by { r.Author }</p>
+					<p class="text-secondary mb-2">by { r.Author }</p>
 				}
 				if r.Description != "" {
-					<div class="content">
-						<p>{ r.Description }</p>
-					</div>
+					<p class="mb-3">{ r.Description }</p>
 				}
-				<div class="tags are-medium mb-4">
+				<div class="badge-group mb-3">
 					if r.PrepTime != "" {
-						<span class="tag is-info is-light">{ fmt.Sprintf("Prep: %s", r.PrepTime) }</span>
+						<span class="badge badge-info">{ fmt.Sprintf("Prep: %s", r.PrepTime) }</span>
 					}
 					if r.CookTime != "" {
-						<span class="tag is-info is-light">{ fmt.Sprintf("Cook: %s", r.CookTime) }</span>
+						<span class="badge badge-info">{ fmt.Sprintf("Cook: %s", r.CookTime) }</span>
 					}
 					if r.TotalTime != "" {
-						<span class="tag is-info">{ fmt.Sprintf("Total: %s", r.TotalTime) }</span>
+						<span class="badge badge-info">{ fmt.Sprintf("Total: %s", r.TotalTime) }</span>
 					}
 					if r.Servings != "" {
-						<span class="tag is-primary is-light">{ fmt.Sprintf("Serves %s", r.Servings) }</span>
+						<span class="badge badge-accent">{ fmt.Sprintf("Serves %s", r.Servings) }</span>
 					}
 					if r.Cuisine != "" {
-						<span class="tag is-success is-light">{ r.Cuisine }</span>
+						<span class="badge badge-success">{ r.Cuisine }</span>
 					}
 					if r.Course != "" {
-						<span class="tag is-warning is-light">{ r.Course }</span>
+						<span class="badge badge-warning">{ r.Course }</span>
 					}
 				</div>
-				<div class="box">
-					<h2 class="title is-4">Ingredients</h2>
+				<div class="panel">
+					<h2 class="section-title">Ingredients</h2>
 					<ul>
 						for _, ing := range r.Ingredients {
 							<li>{ ingredientDisplay(ing) }</li>
 						}
 					</ul>
 				</div>
-				<div class="box">
-					<h2 class="title is-4">Instructions</h2>
-					<ol style="padding-left: 1.5em;">
+				<div class="panel">
+					<h2 class="section-title">Instructions</h2>
+					<ol>
 						for _, inst := range r.Instructions {
-							<li class="mb-3">{ inst.Text }</li>
+							<li class="mb-1">{ inst.Text }</li>
 						}
 					</ol>
 				</div>
-				<div class="box">
-					<h2 class="title is-4">My Notes</h2>
+				<div class="panel">
+					<h2 class="section-title">My Notes</h2>
 					<form id="notes-form" onsubmit="saveNotes(event)">
-						<div class="field">
-							<div class="control">
-								<textarea class="textarea" id="notes-input" name="notes" placeholder="Add your personal notes, tweaks, or modifications...">{ r.Notes }</textarea>
-							</div>
+						<div class="form-group">
+							<textarea class="form-textarea" id="notes-input" name="notes" placeholder="Add your personal notes, tweaks, or modifications...">{ r.Notes }</textarea>
 						</div>
-						<div class="field">
-							<div class="control">
-								<button class="button is-primary" type="submit" id="notes-save-btn">Save Notes</button>
-							</div>
+						<div class="form-group">
+							<button class="btn btn-primary" type="submit" id="notes-save-btn">Save Notes</button>
 						</div>
 					</form>
 				</div>
-				<div id="notes-toast" class="notification is-hidden" style="position: fixed; bottom: 1.5rem; right: 1.5rem; z-index: 100; min-width: 250px;">
-					<button class="delete" onclick="this.parentElement.classList.add('is-hidden')"></button>
+				<div id="notes-toast" class="toast is-hidden">
 					<span id="notes-toast-msg"></span>
+					<button class="toast-close" onclick="this.parentElement.classList.add('is-hidden')">&times;</button>
 				</div>
 				<script>
 					function saveNotes(e) {
@@ -114,22 +108,22 @@ templ RecipeDetail(r dto.RecipeResult, userEmail string) {
 					}
 					function showNotesToast(msg, success) {
 						var toast = document.getElementById('notes-toast');
-						toast.className = 'notification ' + (success ? 'is-success' : 'is-danger');
+						toast.className = 'toast ' + (success ? 'toast-success' : 'toast-danger');
 						document.getElementById('notes-toast-msg').textContent = msg;
 						setTimeout(function() { toast.classList.add('is-hidden'); }, 3000);
 					}
 				</script>
 				if r.SourceURL != "" {
-					<p class="has-text-grey">
+					<p class="text-secondary mt-2">
 						<a href={ templ.SafeURL(r.SourceURL) } target="_blank" rel="noopener">View original recipe</a>
 					</p>
 				}
 			</div>
-			<div class="column is-4">
+			<div class="col-4">
 				if r.ImageURL != "" {
-					<figure class="image">
+					<div class="recipe-image">
 						<img src={ r.ImageURL } alt={ r.Title }/>
-					</figure>
+					</div>
 				}
 			</div>
 		</div>

--- a/internal/interface/web/template/recipe_detail_templ.go
+++ b/internal/interface/web/template/recipe_detail_templ.go
@@ -64,14 +64,14 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"columns\"><div class=\"column is-8\"><h1 class=\"title\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"grid\"><div class=\"col-8\"><h1 class=\"page-title\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(r.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 30, Col: 31}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 30, Col: 36}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -82,14 +82,14 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if r.Author != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<p class=\"subtitle is-6 has-text-grey\">by ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<p class=\"text-secondary mb-2\">by ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(r.Author)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 32, Col: 57}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 32, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -101,37 +101,37 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				}
 			}
 			if r.Description != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"content\"><p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<p class=\"mb-3\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var5 string
 				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(r.Description)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 36, Col: 24}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 35, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</p></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"tags are-medium mb-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"badge-group mb-3\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if r.PrepTime != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<span class=\"tag is-info is-light\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<span class=\"badge badge-info\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Prep: %s", r.PrepTime))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 41, Col: 78}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 39, Col: 74}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -143,14 +143,14 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				}
 			}
 			if r.CookTime != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<span class=\"tag is-info is-light\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<span class=\"badge badge-info\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Cook: %s", r.CookTime))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 44, Col: 78}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 42, Col: 74}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -162,14 +162,14 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				}
 			}
 			if r.TotalTime != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<span class=\"tag is-info\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<span class=\"badge badge-info\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Total: %s", r.TotalTime))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 47, Col: 71}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 45, Col: 76}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -181,14 +181,14 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				}
 			}
 			if r.Servings != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<span class=\"tag is-primary is-light\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<span class=\"badge badge-accent\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Serves %s", r.Servings))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 50, Col: 82}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 48, Col: 77}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
@@ -200,14 +200,14 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				}
 			}
 			if r.Cuisine != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<span class=\"tag is-success is-light\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<span class=\"badge badge-success\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(r.Cuisine)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 53, Col: 55}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 51, Col: 51}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -219,14 +219,14 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				}
 			}
 			if r.Course != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<span class=\"tag is-warning is-light\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<span class=\"badge badge-warning\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(r.Course)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 56, Col: 54}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 54, Col: 50}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -237,7 +237,7 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div><div class=\"box\"><h2 class=\"title is-4\">Ingredients</h2><ul>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div><div class=\"panel\"><h2 class=\"section-title\">Ingredients</h2><ul>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -249,7 +249,7 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(ingredientDisplay(ing))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 63, Col: 35}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 61, Col: 35}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -260,19 +260,19 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</ul></div><div class=\"box\"><h2 class=\"title is-4\">Instructions</h2><ol style=\"padding-left: 1.5em;\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</ul></div><div class=\"panel\"><h2 class=\"section-title\">Instructions</h2><ol>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, inst := range r.Instructions {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<li class=\"mb-3\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<li class=\"mb-1\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var13 string
 				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(inst.Text)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 71, Col: 35}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 69, Col: 35}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 				if templ_7745c5c3_Err != nil {
@@ -283,32 +283,32 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</ol></div><div class=\"box\"><h2 class=\"title is-4\">My Notes</h2><form id=\"notes-form\" onsubmit=\"saveNotes(event)\"><div class=\"field\"><div class=\"control\"><textarea class=\"textarea\" id=\"notes-input\" name=\"notes\" placeholder=\"Add your personal notes, tweaks, or modifications...\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</ol></div><div class=\"panel\"><h2 class=\"section-title\">My Notes</h2><form id=\"notes-form\" onsubmit=\"saveNotes(event)\"><div class=\"form-group\"><textarea class=\"form-textarea\" id=\"notes-input\" name=\"notes\" placeholder=\"Add your personal notes, tweaks, or modifications...\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var14 string
 			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(r.Notes)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 80, Col: 141}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 77, Col: 145}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</textarea></div></div><div class=\"field\"><div class=\"control\"><button class=\"button is-primary\" type=\"submit\" id=\"notes-save-btn\">Save Notes</button></div></div></form></div><div id=\"notes-toast\" class=\"notification is-hidden\" style=\"position: fixed; bottom: 1.5rem; right: 1.5rem; z-index: 100; min-width: 250px;\"><button class=\"delete\" onclick=\"this.parentElement.classList.add('is-hidden')\"></button> <span id=\"notes-toast-msg\"></span></div><script>\n\t\t\t\t\tfunction saveNotes(e) {\n\t\t\t\t\t\te.preventDefault();\n\t\t\t\t\t\tvar btn = document.getElementById('notes-save-btn');\n\t\t\t\t\t\tbtn.classList.add('is-loading');\n\t\t\t\t\t\tvar formData = new FormData(document.getElementById('notes-form'));\n\t\t\t\t\t\tfetch(window.location.pathname + '/notes', {\n\t\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\t\tbody: formData\n\t\t\t\t\t\t}).then(function(resp) {\n\t\t\t\t\t\t\treturn resp.json().then(function(data) {\n\t\t\t\t\t\t\t\treturn { ok: resp.ok, data: data };\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t}).then(function(result) {\n\t\t\t\t\t\t\tshowNotesToast(result.ok ? result.data.message : result.data.error, result.ok);\n\t\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\t\tshowNotesToast('Failed to save notes', false);\n\t\t\t\t\t\t}).finally(function() {\n\t\t\t\t\t\t\tbtn.classList.remove('is-loading');\n\t\t\t\t\t\t});\n\t\t\t\t\t}\n\t\t\t\t\tfunction showNotesToast(msg, success) {\n\t\t\t\t\t\tvar toast = document.getElementById('notes-toast');\n\t\t\t\t\t\ttoast.className = 'notification ' + (success ? 'is-success' : 'is-danger');\n\t\t\t\t\t\tdocument.getElementById('notes-toast-msg').textContent = msg;\n\t\t\t\t\t\tsetTimeout(function() { toast.classList.add('is-hidden'); }, 3000);\n\t\t\t\t\t}\n\t\t\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</textarea></div><div class=\"form-group\"><button class=\"btn btn-primary\" type=\"submit\" id=\"notes-save-btn\">Save Notes</button></div></form></div><div id=\"notes-toast\" class=\"toast is-hidden\"><span id=\"notes-toast-msg\"></span> <button class=\"toast-close\" onclick=\"this.parentElement.classList.add('is-hidden')\">&times;</button></div><script>\n\t\t\t\t\tfunction saveNotes(e) {\n\t\t\t\t\t\te.preventDefault();\n\t\t\t\t\t\tvar btn = document.getElementById('notes-save-btn');\n\t\t\t\t\t\tbtn.classList.add('is-loading');\n\t\t\t\t\t\tvar formData = new FormData(document.getElementById('notes-form'));\n\t\t\t\t\t\tfetch(window.location.pathname + '/notes', {\n\t\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\t\tbody: formData\n\t\t\t\t\t\t}).then(function(resp) {\n\t\t\t\t\t\t\treturn resp.json().then(function(data) {\n\t\t\t\t\t\t\t\treturn { ok: resp.ok, data: data };\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t}).then(function(result) {\n\t\t\t\t\t\t\tshowNotesToast(result.ok ? result.data.message : result.data.error, result.ok);\n\t\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\t\tshowNotesToast('Failed to save notes', false);\n\t\t\t\t\t\t}).finally(function() {\n\t\t\t\t\t\t\tbtn.classList.remove('is-loading');\n\t\t\t\t\t\t});\n\t\t\t\t\t}\n\t\t\t\t\tfunction showNotesToast(msg, success) {\n\t\t\t\t\t\tvar toast = document.getElementById('notes-toast');\n\t\t\t\t\t\ttoast.className = 'toast ' + (success ? 'toast-success' : 'toast-danger');\n\t\t\t\t\t\tdocument.getElementById('notes-toast-msg').textContent = msg;\n\t\t\t\t\t\tsetTimeout(function() { toast.classList.add('is-hidden'); }, 3000);\n\t\t\t\t\t}\n\t\t\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if r.SourceURL != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<p class=\"has-text-grey\"><a href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<p class=\"text-secondary mt-2\"><a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var15 templ.SafeURL
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(r.SourceURL))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 124, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 118, Col: 42}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
@@ -319,19 +319,19 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div><div class=\"column is-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div><div class=\"col-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if r.ImageURL != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<figure class=\"image\"><img src=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div class=\"recipe-image\"><img src=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(r.ImageURL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 131, Col: 27}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 125, Col: 27}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
@@ -344,13 +344,13 @@ func RecipeDetail(r dto.RecipeResult, userEmail string) templ.Component {
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(r.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 131, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_detail.templ`, Line: 125, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\"></figure>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\"></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/internal/interface/web/template/recipe_import.templ
+++ b/internal/interface/web/template/recipe_import.templ
@@ -2,52 +2,44 @@ package template
 
 templ RecipeImport(userEmail string) {
 	@Layout("Import Recipe", userEmail) {
-		<div class="columns">
-			<div class="column is-6 is-offset-3">
-				<h1 class="title">Import Recipe</h1>
-				<p class="subtitle">Paste a recipe URL to import it into your collection.</p>
-				<div class="box" data-signals:url="" data-signals:importing="false">
-					<div class="field">
-						<label class="label">Recipe URL</label>
-						<div class="control">
-							<input
-								class="input"
-								type="url"
-								placeholder="https://example.com/recipe"
-								data-bind:url
-							/>
-						</div>
-					</div>
-					<div class="field">
-						<div class="control">
-							<button
-								class="button is-primary"
-								data-on:click="@post('/import/submit')"
-								data-attr:disabled="$importing"
-								data-class:is-loading="$importing"
-							>
-								Import Recipe
-							</button>
-						</div>
-					</div>
-					<div id="import-result"></div>
-				</div>
+		<h1 class="page-title">Import Recipe</h1>
+		<p class="page-subtitle">Paste a recipe URL to import it into your collection.</p>
+		<div class="panel" data-signals:url="" data-signals:importing="false">
+			<div class="form-group">
+				<label class="form-label">Recipe URL</label>
+				<input
+					class="form-input"
+					type="url"
+					placeholder="https://example.com/recipe"
+					data-bind:url
+				/>
 			</div>
+			<div class="form-group">
+				<button
+					class="btn btn-primary"
+					data-on:click="@post('/import/submit')"
+					data-attr:disabled="$importing"
+					data-class:is-loading="$importing"
+				>
+					Import Recipe
+				</button>
+			</div>
+			<div id="import-result"></div>
 		</div>
 	}
 }
 
 templ ImportSuccess(title string, id string) {
-	<div id="import-result" class="notification is-success mt-4">
+	<div id="import-result" class="alert alert-success mt-2">
 		<p>
 			Successfully imported <strong>{ title }</strong>!
 		</p>
-		<a href={ templ.SafeURL("/recipes/" + id) } class="button is-small is-white mt-2">View Recipe</a>
+		<a href={ templ.SafeURL("/recipes/" + id) } class="btn btn-ghost btn-sm mt-1">View Recipe</a>
 	</div>
 }
 
 templ ImportError(msg string) {
-	<div id="import-result" class="notification is-danger mt-4">
+	<div id="import-result" class="alert alert-danger mt-2">
 		<p>{ msg }</p>
 	</div>
 }

--- a/internal/interface/web/template/recipe_import_templ.go
+++ b/internal/interface/web/template/recipe_import_templ.go
@@ -41,7 +41,7 @@ func RecipeImport(userEmail string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"columns\"><div class=\"column is-6 is-offset-3\"><h1 class=\"title\">Import Recipe</h1><p class=\"subtitle\">Paste a recipe URL to import it into your collection.</p><div class=\"box\" data-signals:url=\"\" data-signals:importing=\"false\"><div class=\"field\"><label class=\"label\">Recipe URL</label><div class=\"control\"><input class=\"input\" type=\"url\" placeholder=\"https://example.com/recipe\" data-bind:url></div></div><div class=\"field\"><div class=\"control\"><button class=\"button is-primary\" data-on:click=\"@post('/import/submit')\" data-attr:disabled=\"$importing\" data-class:is-loading=\"$importing\">Import Recipe</button></div></div><div id=\"import-result\"></div></div></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h1 class=\"page-title\">Import Recipe</h1><p class=\"page-subtitle\">Paste a recipe URL to import it into your collection.</p><div class=\"panel\" data-signals:url=\"\" data-signals:importing=\"false\"><div class=\"form-group\"><label class=\"form-label\">Recipe URL</label> <input class=\"form-input\" type=\"url\" placeholder=\"https://example.com/recipe\" data-bind:url></div><div class=\"form-group\"><button class=\"btn btn-primary\" data-on:click=\"@post('/import/submit')\" data-attr:disabled=\"$importing\" data-class:is-loading=\"$importing\">Import Recipe</button></div><div id=\"import-result\"></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -76,14 +76,14 @@ func ImportSuccess(title string, id string) templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div id=\"import-result\" class=\"notification is-success mt-4\"><p>Successfully imported <strong>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div id=\"import-result\" class=\"alert alert-success mt-2\"><p>Successfully imported <strong>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_import.templ`, Line: 43, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_import.templ`, Line: 35, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -96,13 +96,13 @@ func ImportSuccess(title string, id string) templ.Component {
 		var templ_7745c5c3_Var5 templ.SafeURL
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/recipes/" + id))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_import.templ`, Line: 45, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_import.templ`, Line: 37, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" class=\"button is-small is-white mt-2\">View Recipe</a></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" class=\"btn btn-ghost btn-sm mt-1\">View Recipe</a></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -131,14 +131,14 @@ func ImportError(msg string) templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"import-result\" class=\"notification is-danger mt-4\"><p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"import-result\" class=\"alert alert-danger mt-2\"><p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(msg)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_import.templ`, Line: 51, Col: 10}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/recipe_import.templ`, Line: 43, Col: 10}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {

--- a/internal/interface/web/template/recipe_list.templ
+++ b/internal/interface/web/template/recipe_list.templ
@@ -6,18 +6,16 @@ import (
 
 templ RecipeList(result dto.RecipeListResult, userEmail string) {
 	@Layout("Browse Recipes", userEmail) {
-		<h1 class="title">Browse Recipes</h1>
+		<h1 class="page-title">Browse Recipes</h1>
 		<div data-signals:search="">
-			<div class="field mb-5">
-				<div class="control">
-					<input
-						class="input is-medium"
-						type="text"
-						placeholder="Search recipes..."
-						data-bind:search
-						data-on:keyup__debounce.300ms="@get('/recipes/search')"
-					/>
-				</div>
+			<div class="form-group mb-3">
+				<input
+					class="form-input input-lg"
+					type="text"
+					placeholder="Search recipes..."
+					data-bind:search
+					data-on:keyup__debounce.300ms="@get('/recipes/search')"
+				/>
 			</div>
 		</div>
 		<div id="browse-results">
@@ -29,15 +27,13 @@ templ RecipeList(result dto.RecipeListResult, userEmail string) {
 templ BrowseResults(result dto.RecipeListResult) {
 	<div id="browse-results">
 		if len(result.Recipes) == 0 {
-			<div class="notification is-info is-light">
+			<div class="alert alert-info">
 				No recipes found. <a href="/import">Import one</a> to get started!
 			</div>
 		} else {
-			<div class="columns is-multiline">
+			<div class="card-grid">
 				for _, r := range result.Recipes {
-					<div class="column is-4">
-						@RecipeCard(r)
-					</div>
+					@RecipeCard(r)
 				}
 			</div>
 			@Pagination(result.Total, result.Offset, result.Limit)
@@ -48,15 +44,13 @@ templ BrowseResults(result dto.RecipeListResult) {
 templ BrowseSearchResults(recipes []dto.RecipeResult) {
 	<div id="browse-results">
 		if len(recipes) == 0 {
-			<div class="notification is-info is-light">
+			<div class="alert alert-info">
 				No recipes match your search.
 			</div>
 		} else {
-			<div class="columns is-multiline">
+			<div class="card-grid">
 				for _, r := range recipes {
-					<div class="column is-4">
-						@RecipeCard(r)
-					</div>
+					@RecipeCard(r)
 				}
 			</div>
 		}

--- a/internal/interface/web/template/recipe_list_templ.go
+++ b/internal/interface/web/template/recipe_list_templ.go
@@ -45,7 +45,7 @@ func RecipeList(result dto.RecipeListResult, userEmail string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h1 class=\"title\">Browse Recipes</h1><div data-signals:search=\"\"><div class=\"field mb-5\"><div class=\"control\"><input class=\"input is-medium\" type=\"text\" placeholder=\"Search recipes...\" data-bind:search data-on:keyup__debounce.300ms=\"@get('/recipes/search')\"></div></div></div><div id=\"browse-results\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h1 class=\"page-title\">Browse Recipes</h1><div data-signals:search=\"\"><div class=\"form-group mb-3\"><input class=\"form-input input-lg\" type=\"text\" placeholder=\"Search recipes...\" data-bind:search data-on:keyup__debounce.300ms=\"@get('/recipes/search')\"></div></div><div id=\"browse-results\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -93,30 +93,22 @@ func BrowseResults(result dto.RecipeListResult) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if len(result.Recipes) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"notification is-info is-light\">No recipes found. <a href=\"/import\">Import one</a> to get started!</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"alert alert-info\">No recipes found. <a href=\"/import\">Import one</a> to get started!</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"columns is-multiline\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"card-grid\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, r := range result.Recipes {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"column is-4\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
 				templ_7745c5c3_Err = RecipeCard(r).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -125,7 +117,7 @@ func BrowseResults(result dto.RecipeListResult) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -154,40 +146,32 @@ func BrowseSearchResults(recipes []dto.RecipeResult) templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div id=\"browse-results\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div id=\"browse-results\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(recipes) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"notification is-info is-light\">No recipes match your search.</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"alert alert-info\">No recipes match your search.</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"columns is-multiline\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"card-grid\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, r := range recipes {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"column is-4\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
 				templ_7745c5c3_Err = RecipeCard(r).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/interface/web/template/register.templ
+++ b/internal/interface/web/template/register.templ
@@ -2,42 +2,32 @@ package template
 
 templ Register(errMsg string) {
 	@Layout("Register", "") {
-		<div class="columns">
-			<div class="column is-4 is-offset-4">
-				<h1 class="title">Register</h1>
-				if errMsg != "" {
-					<div class="notification is-danger">{ errMsg }</div>
-				}
-				<form method="POST" action="/register">
-					<div class="field">
-						<label class="label">Email</label>
-						<div class="control">
-							<input class="input" type="email" name="email" placeholder="you@example.com" required/>
-						</div>
-					</div>
-					<div class="field">
-						<label class="label">Password</label>
-						<div class="control">
-							<input class="input" type="password" name="password" minlength="8" required/>
-						</div>
-						<p class="help">Must be at least 8 characters</p>
-					</div>
-					<div class="field">
-						<label class="label">Confirm Password</label>
-						<div class="control">
-							<input class="input" type="password" name="confirm" minlength="8" required/>
-						</div>
-					</div>
-					<div class="field">
-						<div class="control">
-							<button class="button is-primary is-fullwidth" type="submit">Register</button>
-						</div>
-					</div>
-				</form>
-				<p class="has-text-centered mt-4">
-					Already have an account? <a href="/login">Login</a>
-				</p>
-			</div>
+		<div class="auth-container">
+			<h1 class="page-title">Register</h1>
+			if errMsg != "" {
+				<div class="alert alert-danger">{ errMsg }</div>
+			}
+			<form method="POST" action="/register">
+				<div class="form-group">
+					<label class="form-label">Email</label>
+					<input class="form-input" type="email" name="email" placeholder="you@example.com" required/>
+				</div>
+				<div class="form-group">
+					<label class="form-label">Password</label>
+					<input class="form-input" type="password" name="password" minlength="8" required/>
+					<p class="form-help">Must be at least 8 characters</p>
+				</div>
+				<div class="form-group">
+					<label class="form-label">Confirm Password</label>
+					<input class="form-input" type="password" name="confirm" minlength="8" required/>
+				</div>
+				<div class="form-group">
+					<button class="btn btn-primary btn-block" type="submit">Register</button>
+				</div>
+			</form>
+			<p class="text-center text-secondary mt-3">
+				Already have an account? <a href="/login">Login</a>
+			</p>
 		</div>
 	}
 }

--- a/internal/interface/web/template/register_templ.go
+++ b/internal/interface/web/template/register_templ.go
@@ -41,19 +41,19 @@ func Register(errMsg string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"columns\"><div class=\"column is-4 is-offset-4\"><h1 class=\"title\">Register</h1>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"auth-container\"><h1 class=\"page-title\">Register</h1>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if errMsg != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"notification is-danger\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"alert alert-danger\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var3 string
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(errMsg)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/register.templ`, Line: 9, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/register.templ`, Line: 8, Col: 44}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
@@ -64,7 +64,7 @@ func Register(errMsg string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<form method=\"POST\" action=\"/register\"><div class=\"field\"><label class=\"label\">Email</label><div class=\"control\"><input class=\"input\" type=\"email\" name=\"email\" placeholder=\"you@example.com\" required></div></div><div class=\"field\"><label class=\"label\">Password</label><div class=\"control\"><input class=\"input\" type=\"password\" name=\"password\" minlength=\"8\" required></div><p class=\"help\">Must be at least 8 characters</p></div><div class=\"field\"><label class=\"label\">Confirm Password</label><div class=\"control\"><input class=\"input\" type=\"password\" name=\"confirm\" minlength=\"8\" required></div></div><div class=\"field\"><div class=\"control\"><button class=\"button is-primary is-fullwidth\" type=\"submit\">Register</button></div></div></form><p class=\"has-text-centered mt-4\">Already have an account? <a href=\"/login\">Login</a></p></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<form method=\"POST\" action=\"/register\"><div class=\"form-group\"><label class=\"form-label\">Email</label> <input class=\"form-input\" type=\"email\" name=\"email\" placeholder=\"you@example.com\" required></div><div class=\"form-group\"><label class=\"form-label\">Password</label> <input class=\"form-input\" type=\"password\" name=\"password\" minlength=\"8\" required><p class=\"form-help\">Must be at least 8 characters</p></div><div class=\"form-group\"><label class=\"form-label\">Confirm Password</label> <input class=\"form-input\" type=\"password\" name=\"confirm\" minlength=\"8\" required></div><div class=\"form-group\"><button class=\"btn btn-primary btn-block\" type=\"submit\">Register</button></div></form><p class=\"text-center text-secondary mt-3\">Already have an account? <a href=\"/login\">Login</a></p></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/internal/interface/web/template/search_results.templ
+++ b/internal/interface/web/template/search_results.templ
@@ -8,27 +8,19 @@ import (
 templ SearchResults(recipes []dto.RecipeResult) {
 	<div id="search-results">
 		if len(recipes) == 0 {
-			<p class="has-text-grey mt-3">No recipes found.</p>
+			<p class="text-muted mt-2">No recipes found.</p>
 		} else {
-			<p class="has-text-grey mt-3 mb-3">{ fmt.Sprintf("Found %d recipe(s)", len(recipes)) }</p>
+			<p class="text-secondary mt-2 mb-2">{ fmt.Sprintf("Found %d recipe(s)", len(recipes)) }</p>
 			for _, r := range recipes {
-				<div class="box p-3 mb-2">
-					<div class="columns is-vcentered is-mobile">
-						if r.ImageURL != "" {
-							<div class="column is-narrow">
-								<figure class="image is-48x48">
-									<img src={ r.ImageURL } alt={ r.Title } style="object-fit: cover; border-radius: 4px;"/>
-								</figure>
-							</div>
+				<div class="search-result">
+					if r.ImageURL != "" {
+						<img src={ r.ImageURL } alt={ r.Title }/>
+					}
+					<div class="search-result-info">
+						<a href={ templ.SafeURL(fmt.Sprintf("/recipes/%s", r.ID)) }>{ r.Title }</a>
+						if r.Author != "" {
+							<span class="search-result-author"> by { r.Author }</span>
 						}
-						<div class="column">
-							<a href={ templ.SafeURL(fmt.Sprintf("/recipes/%s", r.ID)) }>
-								<strong>{ r.Title }</strong>
-							</a>
-							if r.Author != "" {
-								<span class="has-text-grey is-size-7"> by { r.Author }</span>
-							}
-						</div>
 					</div>
 				</div>
 			}

--- a/internal/interface/web/template/search_results_templ.go
+++ b/internal/interface/web/template/search_results_templ.go
@@ -39,19 +39,19 @@ func SearchResults(recipes []dto.RecipeResult) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if len(recipes) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<p class=\"has-text-grey mt-3\">No recipes found.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<p class=\"text-muted mt-2\">No recipes found.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<p class=\"has-text-grey mt-3 mb-3\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<p class=\"text-secondary mt-2 mb-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Found %d recipe(s)", len(recipes)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 13, Col: 87}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 13, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -62,19 +62,19 @@ func SearchResults(recipes []dto.RecipeResult) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			for _, r := range recipes {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"box p-3 mb-2\"><div class=\"columns is-vcentered is-mobile\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"search-result\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if r.ImageURL != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"column is-narrow\"><figure class=\"image is-48x48\"><img src=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<img src=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var3 string
 					templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(r.ImageURL)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 20, Col: 30}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 17, Col: 27}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 					if templ_7745c5c3_Err != nil {
@@ -87,56 +87,56 @@ func SearchResults(recipes []dto.RecipeResult) templ.Component {
 					var templ_7745c5c3_Var4 string
 					templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(r.Title)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 20, Col: 46}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 17, Col: 43}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" style=\"object-fit: cover; border-radius: 4px;\"></figure></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"column\"><a href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"search-result-info\"><a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var5 templ.SafeURL
 				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/recipes/%s", r.ID)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 25, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 20, Col: 63}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\"><strong>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(r.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 26, Col: 25}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 20, Col: 75}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</strong></a> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</a> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if r.Author != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<span class=\"has-text-grey is-size-7\">by ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<span class=\"search-result-author\">by ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var7 string
 					templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(r.Author)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 29, Col: 60}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/template/search_results.templ`, Line: 22, Col: 56}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 					if templ_7745c5c3_Err != nil {
@@ -147,7 +147,7 @@ func SearchResults(recipes []dto.RecipeResult) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,679 @@
+/* ========================================
+   RecipeBox — Oxide Design System
+   ======================================== */
+
+/* --- Design Tokens --- */
+:root {
+  --bg-page: #080F11;
+  --bg-raise: #101618;
+  --bg-secondary: #141B1D;
+  --bg-hover: #1C2225;
+
+  --border: #2D3335;
+  --border-hover: #404647;
+
+  --text-muted: #5B5F61;
+  --text-tertiary: #7e8385;
+  --text-secondary: #A1A4A5;
+  --text-default: #B8BBBC;
+  --text-bright: #D7D8D9;
+  --text-white: #FEFFFF;
+
+  --accent: #48d597;
+  --accent-hover: #20A36C;
+  --accent-muted: #236A4C;
+  --accent-bg: #162322;
+
+  --error: #FB6E88;
+  --error-bg: #231517;
+  --warning: #F5B944;
+  --warning-bg: #292013;
+  --info: #8BA1FF;
+  --info-bg: #1E202D;
+  --success: #48d597;
+  --success-bg: #162322;
+
+  --font-mono: 'JetBrains Mono', monospace;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+
+  --radius: 2px;
+}
+
+/* --- Reset & Base --- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-page);
+  color: var(--text-default);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent-hover);
+}
+
+strong {
+  font-weight: 600;
+}
+
+ul, ol {
+  padding-left: 1.5em;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* --- Layout --- */
+.container {
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.page-content {
+  padding: 2.5rem 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1.5rem;
+}
+
+.col-4 { grid-column: span 4; }
+.col-6 { grid-column: span 6; }
+.col-8 { grid-column: span 8; }
+.col-12 { grid-column: span 12; }
+.col-offset-2 { grid-column-start: 3; }
+.col-offset-3 { grid-column-start: 4; }
+.col-offset-4 { grid-column-start: 5; }
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+/* --- Navbar --- */
+.navbar {
+  background: var(--bg-raise);
+  border-bottom: 1px solid var(--border);
+}
+
+.navbar .container {
+  display: flex;
+  align-items: center;
+  height: 3.5rem;
+  position: relative;
+}
+
+.navbar-brand {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--accent);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+}
+
+.navbar-brand:hover {
+  color: var(--accent-hover);
+}
+
+.navbar-menu {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+.navbar-links {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-left: 2rem;
+}
+
+.navbar-links a {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0 1rem;
+  height: 3.5rem;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s, background 0.15s;
+}
+
+.navbar-links a:hover {
+  color: var(--text-white);
+  background: var(--bg-hover);
+}
+
+.navbar-end {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.navbar-email {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.navbar-burger {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  margin-left: auto;
+  line-height: 1;
+}
+
+.navbar-burger:hover {
+  color: var(--text-white);
+}
+
+/* --- Typography --- */
+.page-title {
+  font-family: var(--font-mono);
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--text-white);
+  margin-bottom: 0.5rem;
+}
+
+.page-subtitle {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.section-title {
+  font-family: var(--font-mono);
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin-bottom: 1rem;
+}
+
+.text-muted { color: var(--text-muted); }
+.text-secondary { color: var(--text-secondary); }
+.text-center { text-align: center; }
+.text-sm { font-size: 0.85rem; }
+
+/* --- Panel --- */
+.panel {
+  background: var(--bg-raise);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.panel ul li,
+.panel ol li {
+  margin-bottom: 0.5rem;
+}
+
+/* --- Card --- */
+.card {
+  background: var(--bg-raise);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+
+.card:hover {
+  border-color: var(--border-hover);
+}
+
+.card-image img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  display: block;
+}
+
+.card-body {
+  padding: 1.25rem;
+}
+
+.card-title {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.card-title a {
+  color: var(--text-bright);
+}
+
+.card-title a:hover {
+  color: var(--accent);
+}
+
+.card-subtitle {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+  margin-bottom: 0.75rem;
+}
+
+/* --- Badges --- */
+.badge-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 0.2em 0.6em;
+  border-radius: var(--radius);
+  letter-spacing: 0.02em;
+}
+
+.badge-info {
+  background: var(--info-bg);
+  color: var(--info);
+}
+
+.badge-success {
+  background: var(--success-bg);
+  color: var(--success);
+}
+
+.badge-warning {
+  background: var(--warning-bg);
+  color: var(--warning);
+}
+
+.badge-accent {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+/* --- Forms --- */
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.form-input,
+.form-textarea {
+  width: 100%;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-default);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  padding: 0.6em 0.85em;
+  transition: border-color 0.15s;
+}
+
+.form-input:focus,
+.form-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.form-input::placeholder,
+.form-textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.form-input.input-lg {
+  font-size: 1.1rem;
+  padding: 0.75em 1em;
+}
+
+.form-textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.form-help {
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+  margin-top: 0.35rem;
+}
+
+/* --- Buttons --- */
+.btn {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 0.55em 1.25em;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  text-decoration: none;
+  line-height: 1.5;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--bg-page);
+  font-weight: 600;
+}
+
+.btn-primary:hover {
+  background: var(--accent-hover);
+  color: var(--bg-page);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+
+.btn-ghost:hover {
+  border-color: var(--border-hover);
+  color: var(--text-default);
+}
+
+.btn-sm {
+  font-size: 0.75rem;
+  padding: 0.35em 0.85em;
+}
+
+.btn-block {
+  width: 100%;
+}
+
+.btn:disabled,
+.btn[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn.is-loading {
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.btn.is-loading::after {
+  content: '';
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* --- Alerts --- */
+.alert {
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  border-left: 3px solid;
+  font-size: 0.95rem;
+}
+
+.alert-info {
+  background: var(--info-bg);
+  color: var(--info);
+  border-left-color: var(--info);
+}
+
+.alert-success {
+  background: var(--success-bg);
+  color: var(--success);
+  border-left-color: var(--success);
+}
+
+.alert-danger {
+  background: var(--error-bg);
+  color: var(--error);
+  border-left-color: var(--error);
+}
+
+.alert-warning {
+  background: var(--warning-bg);
+  color: var(--warning);
+  border-left-color: var(--warning);
+}
+
+.alert a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+/* --- Toast --- */
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 100;
+  min-width: 250px;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius);
+  border-left: 3px solid;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.toast-success {
+  background: var(--success-bg);
+  color: var(--success);
+  border-left-color: var(--success);
+}
+
+.toast-danger {
+  background: var(--error-bg);
+  color: var(--error);
+  border-left-color: var(--error);
+}
+
+.toast-close {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.2rem;
+  cursor: pointer;
+  margin-left: auto;
+  opacity: 0.7;
+  line-height: 1;
+}
+
+.toast-close:hover {
+  opacity: 1;
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+/* --- Search Results --- */
+.search-result {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 0.5rem;
+  transition: border-color 0.15s;
+}
+
+.search-result:hover {
+  border-color: var(--border-hover);
+}
+
+.search-result img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  flex-shrink: 0;
+}
+
+.search-result-info a {
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.search-result-info a:hover {
+  color: var(--accent);
+}
+
+.search-result-author {
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+}
+
+/* --- Pagination --- */
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.pagination-btn {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 0.5em 1.25em;
+  background: var(--bg-raise);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.pagination-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* --- Recipe Detail --- */
+.recipe-image img {
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+
+/* --- Auth Pages --- */
+.auth-container {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+/* --- Spacing Utilities --- */
+.mt-1 { margin-top: 0.5rem; }
+.mt-2 { margin-top: 1rem; }
+.mt-3 { margin-top: 1.5rem; }
+.mt-4 { margin-top: 2rem; }
+.mb-1 { margin-bottom: 0.5rem; }
+.mb-2 { margin-bottom: 1rem; }
+.mb-3 { margin-bottom: 1.5rem; }
+.mb-4 { margin-bottom: 2rem; }
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+  .navbar-burger {
+    display: block;
+  }
+
+  .navbar-menu {
+    display: none;
+    position: absolute;
+    top: 3.5rem;
+    left: -1.5rem;
+    right: -1.5rem;
+    background: var(--bg-raise);
+    border-bottom: 1px solid var(--border);
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0.5rem 0;
+    z-index: 50;
+  }
+
+  .navbar-menu.is-open {
+    display: flex;
+  }
+
+  .navbar-links {
+    flex-direction: column;
+    margin-left: 0;
+  }
+
+  .navbar-links a {
+    height: auto;
+    padding: 0.75rem 1.5rem;
+  }
+
+  .navbar-end {
+    border-top: 1px solid var(--border);
+    padding: 0.75rem 1.5rem;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-left: 0;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .col-4, .col-6, .col-8 {
+    grid-column: span 1;
+  }
+
+  .col-offset-2, .col-offset-3, .col-offset-4 {
+    grid-column-start: auto;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Replace Bulma CSS framework with a custom Oxide design system using Inter and JetBrains Mono fonts
- Simplify HTML markup across all templ templates with new utility classes
- Add `static/style.css` and static file serving via Echo

## Test plan
- [ ] Verify all pages render correctly (home, browse, recipe detail, import, login, register)
- [ ] Check responsive layout and navbar burger menu on mobile
- [ ] Confirm search, pagination, and import flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)